### PR TITLE
fix : 피드 페이지 태그검색시 store에 저장된 태그 초기화

### DIFF
--- a/src/components/feed/TagSearch.tsx
+++ b/src/components/feed/TagSearch.tsx
@@ -76,6 +76,7 @@ const TagSearch = (): JSX.Element => {
     // 검색 태그 초기화
     const onInitInput = () => {
         setTagName("");
+        tag.onInitTagList();
     }
 
     const handleChangeInput = (e: ChangeEvent) => {


### PR DESCRIPTION
[해결방안]
- 태그 검색시 페이지 이동시켜줄때 tag state 를 초기화 시켜줌