### PR TITLE
fix : issue#98 피드 검색후 뒤로가기시 undefinded 검색되는 버그 수정

### DIFF
--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -15,12 +15,12 @@ const Feed = () : JSX.Element => {
     const feedType = useFeedType();
     const {search} = router.query;
 
-    const onChangeFeedType = () =>{
-        feedType.onChangeSearchView();
-    }
-
     useEffect(()=> {
-        search && onChangeFeedType();
+        search
+            ? feedType.onChangeSearchView()
+            : feedType.type === 'LIST' || feedType.type === 'SEARCH'
+                ? feedType.onChangeListView()
+                : feedType.onChangeCardView();
     },[search])
 
     return (


### PR DESCRIPTION
[해결방안]
- 피드 페이지에서 search Param falsy 확인 후 feedType State를 변경해준다.