### PR TITLE
fix : issue# 147 interceptor 에러 캐치 버그 수정

### DIFF
--- a/src/security/axios.ts
+++ b/src/security/axios.ts
@@ -23,7 +23,7 @@ securityAxios.interceptors.response.use((config) => {
                 securityAxios.defaults.headers.common['Authorization'] = `Bearer ${response.data}`;
                 return securityAxios(originalRequest);
             } catch (e) {
-                if (error.response.body === '재발급 실패') {
+                if (e.response.data === '재발급 실패') {
                     removeCookie('userId');
                     removeCookie('refreshToken');
                     window.location.href = 'login';


### PR DESCRIPTION
[해결방안]
-  if (error.response.body === '재발급 실패') ->  if (e.response.data === '재발급 실패')
1. error 변수를 잘못 사용함
2. body 가 아닌 data 를 비교 해야함