### PR TITLE
fix : issue#182 쿠시 삭제시 path지정

### DIFF
--- a/src/utils/cookieUtil.ts
+++ b/src/utils/cookieUtil.ts
@@ -11,5 +11,5 @@ export const getCookie = (name : string) => {
 }
 
 export const removeCookie = (name : string) => {
-    return cookies.remove(name);
+    return cookies.remove(name,{path : '/'});
 }


### PR DESCRIPTION
- 주소창으로 profile 페이지 접속시 path가 다르게 잡히는 문제 때문에 cookie 삭제시 path : '/' 로 지정하여 삭제함