### PR TITLE
fix : 게시글 조회수 API 버그 수정 (#654)

### DIFF
--- a/pages/board/[id].tsx
+++ b/pages/board/[id].tsx
@@ -14,16 +14,15 @@ const ViewPage = (): JSX.Element => {
 
     const onLoadView = async () => {
         try {
-            const response = await onClickBoard(id as string);
-            //await queryClient.invalidateQueries(['board', id]);
+            await onClickBoard(id as string);
         } catch (e) {
 
         }
     }
 
     useEffect(() => {
-        onLoadView();
-    }, [])
+        id && onLoadView();
+    }, [id])
 
     const boardQuery = useQuery<IBoardData>(['board', id], () => getBoardView(id as string), {
         enabled: id !== undefined,


### PR DESCRIPTION
** 원인 **
조회수 API 요청시, 게시글에 해당하는 Id가 할당되기전에 요청하여 undefinded가 날라감

** 해결방안 **
id가 Truthy일 경우에만 API 요청
